### PR TITLE
On error exit with non-zero exit code

### DIFF
--- a/webshot
+++ b/webshot
@@ -115,6 +115,7 @@ handleUrl(url, function (url, type) {
 function end (err) {
   if (err) {
     console.error(err)
+    process.exit(1)
   }
 }
 


### PR DESCRIPTION
When error occurs, the CLI command should not exit with exit code 0 (meaning it ended successfully), rather exist with 1 (meaning error occurred).
